### PR TITLE
Allow to map file paths on reduce publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codio-api-js",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "description": "JS client to Codio API",
   "repository": "https://github.com/codio/codio-api-js",
   "author": "Max Kraev <maxim.kraev@gmail.com>",

--- a/src/lib/assignment.ts
+++ b/src/lib/assignment.ts
@@ -10,17 +10,22 @@ import config, { excludePaths } from './config'
 import _ from 'lodash'
 import { info } from './course'
 
+export type PathMap = {
+  source: string
+  destination: string
+}
+
 type YamlRaw = {
   assignment: string | undefined
   assignmentName: string | undefined
-  paths: string[] | undefined
+  paths: (string | PathMap)[] | undefined 
   section: string | string[]
 }
 
 type Yaml = {
   assignment: string | undefined
   assignmentName: string | undefined
-  paths: string[]
+  paths: (string | PathMap)[]
   section: string[][]
 }
 
@@ -225,6 +230,9 @@ async function loadYaml(yamlDir: string): Promise<Yaml[]> {
   for (const file of files) {
     const ymlText = await fs.promises.readFile(path.join(yamlDir, file), {encoding: 'utf-8'})
     let ymls: YamlRaw[] = YAML.parse(ymlText)
+    if (!ymls) {
+      continue
+    }
     if (!_.isArray(ymls)) {
       ymls = [ymls]
     }


### PR DESCRIPTION
https://codio.myjetbrains.com/youtrack/issue/codio-14061

examples:
```yaml
- assignmentName: jupyter guides
  section:  ["Jupyter 1"]
  paths:
    - .codio-jupyter
    - source: Jupyter 1
      destination: ''
```
```yaml
- assignmentName: Java 1
  section:  ["Assignment 1"]
  paths:
    - source: Assignment 1
      destination: code
```

Do not use `./` as a current path, for the `workspace` folder use an empty string as the destination